### PR TITLE
feat: CardList 中增加 local 的过滤和排序规则

### DIFF
--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -20,6 +20,7 @@ import { HelperState } from '../redux/reducers/helper';
 import { downloadAllUnreadFiles, loadMoreCard } from '../redux/actions/ui';
 import { generateCardList } from '../redux/selectors';
 import { ContentInfo } from '../types/data';
+import _ from 'lodash';
 
 const initialState = {
   onTop: true,
@@ -43,9 +44,35 @@ class CardList extends React.PureComponent<CardListProps, typeof initialState> {
   }
 
   public render() {
-    const { contents, threshold, loadMore, unreadFileCount, downloadAllUnread, ...rest } =
-      this.props;
-    const filtered = contents.slice(0, threshold);
+    const {
+      contents,
+      threshold,
+      loadMore,
+      unreadFileCount,
+      downloadAllUnread,
+      filterRules,
+      sortRules,
+      sortOrders,
+      ...rest
+    } = this.props;
+    // 过滤内容
+    let filteredContents = contents;
+    if (filterRules) {
+      for (const filterRule of filterRules) {
+        filteredContents = filteredContents.filter(filterRule.func);
+      }
+    }
+    // 内容排序
+    let sortedContents = filteredContents;
+    if (sortRules && sortOrders) {
+      sortedContents = _.orderBy(
+        sortedContents,
+        sortRules.map((r) => r.func),
+        sortOrders,
+      );
+    }
+    // 名称的文字过滤
+    const filtered = sortedContents.slice(0, threshold);
 
     const canLoadMore = threshold < contents.length;
 
@@ -142,6 +169,9 @@ const mapStateToProps = (state): Partial<CardListProps> => {
     ...generatedCardList,
     unreadFileCount,
     threshold: ui.cardVisibilityThreshold,
+    filterRules: ui.cardSelectFilterRules,
+    sortRules: ui.cardSelectSortRules,
+    sortOrders: ui.cardSortOrders,
   };
 };
 

--- a/src/components/CourseList.tsx
+++ b/src/components/CourseList.tsx
@@ -15,7 +15,13 @@ import { CourseListProps } from '../types/ui';
 import { COURSE_FUNC, COURSE_FUNC_LIST, COURSE_ICON } from '../constants/ui';
 import { STATE_DATA, STATE_HELPER } from '../redux/reducers';
 import { DataState } from '../redux/reducers/data';
-import { setCardFilter, setCardListTitle, setDetailUrl } from '../redux/actions/ui';
+import {
+  setCardFilter,
+  setCardFilterRuleList,
+  setCardListTitle,
+  setCardSortRuleList,
+  setDetailUrl,
+} from '../redux/actions/ui';
 import { HelperState } from '../redux/reducers/helper';
 
 class CourseList extends React.PureComponent<
@@ -75,6 +81,8 @@ class CourseList extends React.PureComponent<
                           // show cards
                           dispatch(setCardFilter(func.type, c));
                           dispatch(setCardListTitle(`${func.name}-${c.name}`));
+                          dispatch(setCardFilterRuleList(func.filterRules));
+                          dispatch(setCardSortRuleList(func.sortRules));
                         } else {
                           dispatch(setDetailUrl(c.url));
                         }

--- a/src/components/SummaryList.tsx
+++ b/src/components/SummaryList.tsx
@@ -17,7 +17,12 @@ import { DataState } from '../redux/reducers/data';
 import { COURSE_MAIN_FUNC, SUMMARY_FUNC_LIST } from '../constants/ui';
 import { ContentInfo, HomeworkInfo } from '../types/data';
 import { HelperState } from '../redux/reducers/helper';
-import { setCardFilter, setCardListTitle } from '../redux/actions/ui';
+import {
+  setCardFilter,
+  setCardFilterRuleList,
+  setCardListTitle,
+  setCardSortRuleList,
+} from '../redux/actions/ui';
 
 class SummaryList extends React.PureComponent<SummaryListProps, never> {
   render() {
@@ -42,6 +47,8 @@ class SummaryList extends React.PureComponent<SummaryListProps, never> {
             onClick={() => {
               dispatch(setCardFilter(func.type));
               dispatch(setCardListTitle(func.name));
+              dispatch(setCardFilterRuleList(func.filterRules));
+              dispatch(setCardSortRuleList(func.sortRules));
             }}
           >
             <ListItemIcon className={styles.list_item_icon}>

--- a/src/components/dialogs/LoginDialog.tsx
+++ b/src/components/dialogs/LoginDialog.tsx
@@ -60,6 +60,7 @@ class LoginDialog extends React.PureComponent<ILoginDialogProps, never> {
             id="username"
             label="用户名/学号"
             type="text"
+            autoComplete="username"
             required
             multiline={false}
             onChange={(e) => {
@@ -68,11 +69,11 @@ class LoginDialog extends React.PureComponent<ILoginDialogProps, never> {
           />
           <TextField
             fullWidth
-            autoFocus
             margin="dense"
             id="password"
             label="密码"
             type="password"
+            autoComplete="current-password"
             required
             multiline={false}
             onChange={(e) => {

--- a/src/constants/filterRule.ts
+++ b/src/constants/filterRule.ts
@@ -1,0 +1,21 @@
+/**
+ * Description: 用于 CardList 中的过滤规则
+ * Author: leonardodalinky
+ * CreatedAt: 12/14/2021
+ * ModifiedAt: 12/14/2021
+ */
+
+import { HomeworkInfo } from '../types/data';
+import { CardFilterRule } from '../types/ui';
+
+const HANDED_HOMEWORK_FILTER_RULE: CardFilterRule = {
+  name: '忽略已交作业',
+  func: (content) => !(content as HomeworkInfo).submitted,
+};
+
+const OUTDATED_HOMEWORK_FILTER_RULE: CardFilterRule = {
+  name: '忽略过期作业',
+  func: (content) => (content as HomeworkInfo).deadline > new Date(),
+};
+
+export const HOMEWORK_FILTER_RULES = [HANDED_HOMEWORK_FILTER_RULE, OUTDATED_HOMEWORK_FILTER_RULE];

--- a/src/constants/fontAwesome.ts
+++ b/src/constants/fontAwesome.ts
@@ -27,6 +27,7 @@ import { faClipboardCheck } from '@fortawesome/free-solid-svg-icons/faClipboardC
 import { faClipboard } from '@fortawesome/free-solid-svg-icons/faClipboard';
 import { faSearch } from '@fortawesome/free-solid-svg-icons/faSearch';
 import { faFilter } from '@fortawesome/free-solid-svg-icons/faFilter';
+import { faSort } from '@fortawesome/free-solid-svg-icons/faSort';
 import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
 import { faAngleLeft } from '@fortawesome/free-solid-svg-icons/faAngleLeft';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
@@ -35,6 +36,9 @@ import { faBan } from '@fortawesome/free-solid-svg-icons/faBan';
 import { faEnvelopeOpen } from '@fortawesome/free-solid-svg-icons/faEnvelopeOpen';
 import { faRandom } from '@fortawesome/free-solid-svg-icons/faRandom';
 import { faStarOfLife } from '@fortawesome/free-solid-svg-icons/faStarOfLife';
+import { faStopwatch } from '@fortawesome/free-solid-svg-icons/faStopwatch';
+import { faCalendarAlt } from '@fortawesome/free-solid-svg-icons/faCalendarAlt';
+import { faFlag } from '@fortawesome/free-solid-svg-icons/faFlag';
 
 const ICON_TO_USE = [
   faThumbtack,
@@ -66,12 +70,16 @@ const ICON_TO_USE = [
   faBars,
   faAngleLeft,
   faFilter,
+  faSort,
   faTimes,
   faTrashAlt,
   faEnvelopeOpen,
   faRandom,
   faBan,
   faStarOfLife,
+  faStopwatch,
+  faCalendarAlt,
+  faFlag,
 ];
 
 ICON_TO_USE.map((i) => library.add(i));

--- a/src/constants/sortRule.ts
+++ b/src/constants/sortRule.ts
@@ -1,0 +1,43 @@
+/**
+ * Description: 用于 CardList 中的排序
+ * Author: leonardodalinky
+ * CreatedAt: 12/13/2021
+ * ModifiedAt: 12/13/2021
+ */
+import { CardSortRule } from '../types/ui';
+import { HomeworkInfo } from '../types/data';
+
+const DATE_SORT_RULE: CardSortRule = {
+  name: '按日期排序',
+  func: (content) => content.date,
+  iconName: 'calendar-alt',
+};
+
+const DDL_SORT_RULE: CardSortRule = {
+  name: '按 DDL 排序',
+  func: (content) => (content as HomeworkInfo).deadline,
+  iconName: 'stopwatch',
+};
+
+const TITLE_SORT_RULE: CardSortRule = {
+  name: '按名称排序',
+  func: (content) => content.title,
+  iconName: 'flag',
+};
+
+const COURSE_NAME_SORT_RULE: CardSortRule = {
+  name: '按课程名称排序',
+  func: (content) => content.courseName,
+  iconName: 'book',
+};
+
+// 普通规则
+export const COMMON_SORT_RULES = [DATE_SORT_RULE, TITLE_SORT_RULE, COURSE_NAME_SORT_RULE];
+
+// 作业规则
+export const HOMEWORK_SORT_RULES = [
+  DDL_SORT_RULE,
+  DATE_SORT_RULE,
+  TITLE_SORT_RULE,
+  COURSE_NAME_SORT_RULE,
+];

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -11,6 +11,8 @@ import {
   toggleChangeSemesterDialog,
 } from '../redux/actions/ui';
 import { markAllRead } from '../redux/actions/data';
+import { COMMON_SORT_RULES, HOMEWORK_SORT_RULES } from './sortRule';
+import { HOMEWORK_FILTER_RULES } from './filterRule';
 
 export const COURSE_MAIN_FUNC: {
   [key: string]: {
@@ -53,30 +55,37 @@ export const COURSE_FUNC: IMenuItemEnum = {
     icon: COURSE_MAIN_FUNC[ContentType.NOTIFICATION].icon,
     name: '课程公告',
     type: ContentType.NOTIFICATION,
+    sortRules: COMMON_SORT_RULES,
   },
   COURSE_SUMMARY: {
     icon: 'info-circle',
     name: '课程综合',
+    sortRules: COMMON_SORT_RULES,
   },
   COURSE_FILE: {
     icon: COURSE_MAIN_FUNC[ContentType.FILE].icon,
     name: '课程文件',
     type: ContentType.FILE,
+    sortRules: COMMON_SORT_RULES,
   },
   COURSE_HOMEWORK: {
     icon: COURSE_MAIN_FUNC[ContentType.HOMEWORK].icon,
     name: '课程作业',
     type: ContentType.HOMEWORK,
+    filterRules: HOMEWORK_FILTER_RULES,
+    sortRules: HOMEWORK_SORT_RULES,
   },
   COURSE_DISCUSSION: {
     icon: COURSE_MAIN_FUNC[ContentType.DISCUSSION].icon,
     name: '课程讨论',
     type: ContentType.DISCUSSION,
+    sortRules: COMMON_SORT_RULES,
   },
   COURSE_QUESTION: {
     icon: COURSE_MAIN_FUNC[ContentType.QUESTION].icon,
     name: '课程答疑',
     type: ContentType.QUESTION,
+    sortRules: COMMON_SORT_RULES,
   },
   COURSE_HOMEPAGE: {
     icon: 'external-link-alt',
@@ -103,26 +112,32 @@ const SUMMARY_FUNC: IMenuItemEnum = {
     icon: COURSE_MAIN_FUNC[ContentType.HOMEWORK].icon,
     name: '所有作业',
     type: ContentType.HOMEWORK,
+    filterRules: HOMEWORK_FILTER_RULES,
+    sortRules: HOMEWORK_SORT_RULES,
   },
   SUMMARY_NOTIFICATIONS: {
     icon: COURSE_MAIN_FUNC[ContentType.NOTIFICATION].icon,
     name: '所有公告',
     type: ContentType.NOTIFICATION,
+    sortRules: COMMON_SORT_RULES,
   },
   SUMMARY_FILES: {
     icon: COURSE_MAIN_FUNC[ContentType.FILE].icon,
     name: '所有文件',
     type: ContentType.FILE,
+    sortRules: COMMON_SORT_RULES,
   },
   SUMMARY_DISCUSSIONS: {
     icon: COURSE_MAIN_FUNC[ContentType.DISCUSSION].icon,
     name: '所有讨论',
     type: ContentType.DISCUSSION,
+    sortRules: COMMON_SORT_RULES,
   },
   SUMMARY_QUESTIONS: {
     icon: COURSE_MAIN_FUNC[ContentType.QUESTION].icon,
     name: '所有答疑',
     type: ContentType.QUESTION,
+    sortRules: COMMON_SORT_RULES,
   },
   SUMMARY_IGNORED: {
     icon: 'trash',

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -96,7 +96,7 @@
 
 .sidebar_filter_group {
   margin-right: -8px;
-  width: 48px;
+  width: 96px;
   display: flex;
   align-items: center;
 
@@ -104,12 +104,12 @@
 }
 
 .sidebar_filter_shown .sidebar_cardlist_name {
-  transform: translateX(-320px); /* 400 - 24*2 - 48 + 8*2 = 320 */
+  transform: translateX(-272px); /* 400 - 24*2 - 48*2 + 8*2 = 272 */
   opacity: 0;
 }
 
 .sidebar_filter_shown .sidebar_filter_group {
-  transform: translateX(-320px);
+  transform: translateX(-272px);
 }
 
 .filter_input {
@@ -134,10 +134,7 @@
 
   opacity: 0;
   transition: opacity .2s ease;
-}
-
-.filter_icon:last-child {
-  margin-left: -24px;
+  justify-content: center;
 }
 
 .filter_icon_shown {
@@ -211,4 +208,8 @@
 .form_control {
     margin: 10px 0 !important;
     min-width: 150px !important;
+}
+
+.sort_menu_item_icon {
+  margin-right: 10px;
 }

--- a/src/redux/actions/actionTypes.ts
+++ b/src/redux/actions/actionTypes.ts
@@ -14,6 +14,13 @@ export enum UiActionType {
   TOGGLE_CHANGE_SEMESTER_DIALOG = 'UI/toggle_change_semester_dialog',
   CARD_FILTER = 'UI/card_filter',
   CARD_LIST_TITLE = 'UI/card_list_title',
+  // CardList 排序规则
+  CARD_SELECT_SORT_RULE = 'UI/card_select_sort_rule',
+  CARD_RESET_SORT_RULE = 'UI/card_reset_sort_rule',
+  CARD_SET_SORT_RULE_LIST = 'UI/card_set_sort_rule_list',
+  // CardList 过滤规则
+  CARD_SELECT_FILTER_RULE = 'UI/card_select_filter_rule',
+  CARD_SET_FILTER_RULE_LIST = 'UI/card_set_filter_rule_list',
   LOAD_MORE_CARD = 'UI/load_more_card',
   SET_DETAIL_URL = 'UI/set_detail_url',
   SET_DETAIL_CONTENT = 'UI/set_detail_content',

--- a/src/redux/actions/ui.ts
+++ b/src/redux/actions/ui.ts
@@ -8,6 +8,7 @@ import { initiateFileDownload } from '../../utils/download';
 import { toggleReadState } from './data';
 import { STATE_HELPER } from '../reducers';
 import { HelperState } from '../reducers/helper';
+import { CardFilterRule, CardSortRule } from '../../types/ui';
 
 interface IUiAction {
   type: UiActionType;
@@ -20,6 +21,12 @@ interface IUiAction {
   title?: string;
   url?: string;
   content?: ContentInfo;
+  // CardList 排序规则
+  sortRule?: CardSortRule;
+  sortOrder?: 'asc' | 'desc';
+  sortRuleList?: CardSortRule[];
+  filterRule?: CardFilterRule;
+  filterRuleList?: CardFilterRule[];
 }
 
 export type UiAction = IUiAction;
@@ -116,6 +123,34 @@ export const setCardFilter = (
 export const setCardListTitle = (title: string): UiAction => ({
   type: UiActionType.CARD_LIST_TITLE,
   title,
+});
+
+export const addCardSelectSortRules = (
+  sortRule: CardSortRule,
+  sortOrder: 'asc' | 'desc',
+): UiAction => ({
+  type: UiActionType.CARD_SELECT_SORT_RULE,
+  sortRule,
+  sortOrder,
+});
+
+export const resetCardSortRule = (): UiAction => ({
+  type: UiActionType.CARD_RESET_SORT_RULE,
+});
+
+export const setCardSortRuleList = (sortRuleList?: CardSortRule[]): UiAction => ({
+  type: UiActionType.CARD_SET_SORT_RULE_LIST,
+  sortRuleList,
+});
+
+export const selectCardFilterRule = (filterRule: CardFilterRule): UiAction => ({
+  type: UiActionType.CARD_SELECT_FILTER_RULE,
+  filterRule,
+});
+
+export const setCardFilterRuleList = (filterRuleList?: CardFilterRule[]): UiAction => ({
+  type: UiActionType.CARD_SET_FILTER_RULE_LIST,
+  filterRuleList,
 });
 
 export const loadMoreCard = (): UiAction => ({

--- a/src/redux/reducers/ui.ts
+++ b/src/redux/reducers/ui.ts
@@ -5,6 +5,7 @@ import { UiActionType } from '../actions/actionTypes';
 import { UiAction } from '../actions/ui';
 import { CARD_BATCH_LOAD_SIZE } from '../../constants';
 import { ContentInfo } from '../../types/data';
+import { CardFilterRule, CardSortRule } from '../../types/ui';
 
 interface IUiState {
   showLoadingProgressBar: boolean;
@@ -24,6 +25,11 @@ interface IUiState {
   cardTypeFilter?: ContentType | null;
   cardVisibilityThreshold: number;
   cardCourseFilter?: CourseInfo;
+  cardSelectSortRules?: CardSortRule[];
+  cardSortOrders?: ('asc' | 'desc')[];
+  cardSortRuleList?: CardSortRule[];
+  cardSelectFilterRules?: CardFilterRule[];
+  cardFilterRuleList?: CardFilterRule[];
   cardListTitle: string;
   detailUrl: string;
   detailContent?: ContentInfo;
@@ -51,6 +57,11 @@ const initialState: UiState = {
   cardTypeFilter: undefined,
   cardVisibilityThreshold: CARD_BATCH_LOAD_SIZE,
   cardCourseFilter: undefined,
+  cardSelectSortRules: undefined,
+  cardSortOrders: undefined,
+  cardSortRuleList: undefined,
+  cardSelectFilterRules: undefined,
+  cardFilterRuleList: undefined,
   cardListTitle: '主页',
   detailUrl: 'welcome.html',
   detailContent: undefined,
@@ -137,6 +148,74 @@ export default function ui(state: UiState = initialState, action: UiAction): UiS
       return {
         ...state,
         cardListTitle: action.title,
+      };
+    case UiActionType.CARD_SELECT_SORT_RULE: {
+      // 增加排序规则，如果已经有了则不加
+      if (
+        state.cardSelectSortRules &&
+        state.cardSelectSortRules.find((value) => value.name === action.sortRule.name) != null
+      ) {
+        return state;
+      }
+      let newRules: CardSortRule[];
+      let newOrders: ('asc' | 'desc')[];
+      if (state.cardSelectSortRules == undefined) {
+        newRules = [action.sortRule];
+      } else {
+        newRules = [...state.cardSelectSortRules];
+        newRules.push(action.sortRule);
+      }
+      if (state.cardSortOrders == undefined) {
+        newOrders = [action.sortOrder];
+      } else {
+        newOrders = [...state.cardSortOrders];
+        newOrders.push(action.sortOrder);
+      }
+      return {
+        ...state,
+        cardSelectSortRules: newRules,
+        cardSortOrders: newOrders,
+      };
+    }
+    case UiActionType.CARD_RESET_SORT_RULE:
+      return {
+        ...state,
+        cardSelectSortRules: undefined,
+        cardSortOrders: undefined,
+      };
+    case UiActionType.CARD_SET_SORT_RULE_LIST:
+      return {
+        ...state,
+        cardSortRuleList: action.sortRuleList,
+        cardSelectSortRules: undefined,
+        cardSortOrders: undefined,
+      };
+    case UiActionType.CARD_SELECT_FILTER_RULE: {
+      // 增加过滤规则
+      let newRules: CardFilterRule[];
+      if (state.cardSelectFilterRules == undefined) {
+        newRules = [action.filterRule];
+      } else {
+        newRules = [...state.cardSelectFilterRules];
+        const findResult = newRules.find((value) => value.name === action.filterRule.name);
+        if (findResult) {
+          // 清除已有
+          newRules = newRules.filter((value) => value.name !== findResult.name);
+        } else {
+          // 新增规则
+          newRules.push(action.filterRule);
+        }
+      }
+      return {
+        ...state,
+        cardSelectFilterRules: newRules,
+      };
+    }
+    case UiActionType.CARD_SET_FILTER_RULE_LIST:
+      return {
+        ...state,
+        cardFilterRuleList: action.filterRuleList,
+        cardSelectFilterRules: undefined,
       };
     case UiActionType.LOAD_MORE_CARD:
       return {

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -4,12 +4,15 @@ import { ContentType, CourseInfo } from 'thu-learn-lib/lib/types';
 
 import { ContentInfo } from './data';
 import { SnackbarType } from './dialogs';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 export interface IMenuItem {
   name: string;
   icon: IconName;
   type?: ContentType | null;
   handler?: (any) => any;
+  filterRules?: CardFilterRule[];
+  sortRules?: CardSortRule[];
 }
 
 export interface IMenuItemEnum {
@@ -35,12 +38,39 @@ interface ICardFilter {
   course: CourseInfo;
 }
 
+// card 排序规则
+interface ICardSortRule {
+  // 规则名称
+  name: string;
+  // 排序 key 指定函数
+  func: (content: ContentInfo) => number | string | Date;
+  // fontAwesome 的图标名称
+  iconName?: IconProp;
+}
+
+export type CardSortRule = ICardSortRule;
+
+// card 排序中的过滤规则
+interface ICardFilterRule {
+  // 规则名称
+  name: string;
+  // 过滤 key 指定函数，返回 true 则为通过
+  func: (content: ContentInfo) => boolean;
+  // fontAwesome 的图标名称
+  iconName?: string;
+}
+
+export type CardFilterRule = ICardFilterRule;
+
 interface ICardListProps extends IDispatchableComponentProps, Partial<ICardFilter> {
   contents: ContentInfo[];
   threshold: number;
   unreadFileCount: number;
   loadMore: () => any;
   downloadAllUnread: (contents: ContentInfo[]) => any;
+  filterRules?: CardFilterRule[];
+  sortRules: CardSortRule[] | undefined;
+  sortOrders?: ('asc' | 'desc')[];
 }
 
 interface ICardProps extends IDispatchableComponentProps {
@@ -64,11 +94,19 @@ interface IAppProps extends IDispatchableComponentProps {
   cardListTitle: string;
   semesterTitle: string;
   latestSemester: boolean;
+  cardSortRuleList: CardSortRule[];
+  cardSelectSortRules: CardSortRule[];
+  cardSelectSortOrders: ('asc' | 'desc')[];
+  cardFilterRuleList?: CardFilterRule[];
+  cardSelectFilterRules?: CardFilterRule[];
   openSidebar: () => any;
   closeSidebar: () => any;
   resetApp: () => any;
   setTitleFilter: (filter: string) => any;
   openChangeSemesterDialog: () => any;
+  addCardSortRule: (rule: CardSortRule, ord: 'asc' | 'desc') => any;
+  resetCardSortRule: () => any;
+  selectCardFilterRule: (rule: CardFilterRule) => any;
 }
 
 export type AppProps = IAppProps;


### PR DESCRIPTION
学长您好，用了这份 Learn-Helper 许久，发现虽然在作业显示上已经有排序规则，但是总感觉不太完善，于是最近两天研究了一下，并自制了一个“栈”式的规则筛选列表（因为太懒不想设计其他的排序和过滤筛选

大致修改有：

- actionTypes 的增加，包括过滤筛选和排序
- 过滤和排序规则（`filterRule` 和 `sortRule`）
- 状态相关的配套修改逻辑

为不影响其他功能，这个功能的主题逻辑几乎完全在 `CardList` 组件中直接 local 的进行，因此假设前提是上层会将**所有的课程信息**一次性全部传给 `CardList` 组件，如果以后需要修改数据来源的逻辑的话（例如动态加载），这个功能可能将不成立。

功能说明：

- “忽略已交作业”和“忽略过期作业”选中后，可以忽略对应的作业，目前仅在作业页面存在
- 排序功能，按照所点击的排序规则依次入栈，规则越靠近栈底则重要性越大
- 排序默认添加“升序”的规则，如果需要“降序”规则，则需要先勾选“降序选择”，再选择排序规则
- “清除选项”可以清空当前的栈
- 栈的状态在筛选菜单的最下方

目前实现的样式如下图：
![cap1](https://user-images.githubusercontent.com/30380541/145941576-0e0b907a-1cc0-4ba4-9697-a25b03f93e53.png)
![cap2](https://user-images.githubusercontent.com/30380541/145941808-8c21a21b-d198-4571-a983-6dade495e67c.png)

