### PR TITLE
fix: 'date' cli doesn't work on Windows

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,7 @@ const isDev = process.env.NODE_ENV === 'development';
 const helperVersion = version;
 const gitVersion = runCmd('git describe --always --dirty');
 const gitBranch = runCmd('git branch --show-current');
+const date = Date();
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -37,7 +38,7 @@ export default defineConfig({
     ),
     __GIT_BRANCH__: JSON.stringify(runCmd('git rev-parse --abbrev-ref HEAD')),
     __BUILD_HOSTNAME__: JSON.stringify(runCmd('hostname')),
-    __BUILD_TIME__: JSON.stringify(runCmd('date +"%Y/%m/%d %T"')),
+    __BUILD_TIME__: JSON.stringify(`date + ${date}`),
     __THU_LEARN_LIB_VERSION__: JSON.stringify(versionThuLearnLib),
     __MUI_VERSION__: JSON.stringify(versionMui),
     __REACT_VERSION__: JSON.stringify(versionReact),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ const isDev = process.env.NODE_ENV === 'development';
 const helperVersion = version;
 const gitVersion = runCmd('git describe --always --dirty');
 const gitBranch = runCmd('git branch --show-current');
-const date = Date();
+const date = new Date();
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -38,7 +38,7 @@ export default defineConfig({
     ),
     __GIT_BRANCH__: JSON.stringify(runCmd('git rev-parse --abbrev-ref HEAD')),
     __BUILD_HOSTNAME__: JSON.stringify(runCmd('hostname')),
-    __BUILD_TIME__: JSON.stringify(`date + ${date}`),
+    __BUILD_TIME__: JSON.stringify(`date + ${date.toLocaleString('zh-CN')}`),
     __THU_LEARN_LIB_VERSION__: JSON.stringify(versionThuLearnLib),
     __MUI_VERSION__: JSON.stringify(versionMui),
     __REACT_VERSION__: JSON.stringify(versionReact),


### PR DESCRIPTION
Using the date object in Node instead of the Linux date command line to solve the issue of being unable to obtain the time on Windows systems.